### PR TITLE
Shorter Option for Find/Replace Panel

### DIFF
--- a/predawn.sublime-theme
+++ b/predawn.sublime-theme
@@ -624,8 +624,9 @@
     },
     {
         "class": "text_line_control",
+        "parents": [{"class": "panel_control"}],
         "settings": ["findreplace_small"],
-        "content_margin": [4, 2, 15, 2]
+        "content_margin": [4, 5, 15, 4]
     },
 
         //


### PR DESCRIPTION
From issue #22

I've added the option `findreplace_small` to make the panel a little smaller so it doesn't overlap with the status messages. I think the option name could be improved but I can't think of any other name.

**From**:

![from1](https://cloud.githubusercontent.com/assets/692077/3179964/c4d4be32-ec2b-11e3-9280-e4d7c0351577.JPG)

![from2](https://cloud.githubusercontent.com/assets/692077/3179965/c7c9ed6a-ec2b-11e3-89fe-953d69874532.JPG)

**To**:

![to1](https://cloud.githubusercontent.com/assets/692077/3179968/d1ca45b2-ec2b-11e3-8da5-cff920971c1e.JPG)

![to2](https://cloud.githubusercontent.com/assets/692077/3179969/d3276b92-ec2b-11e3-8ab6-365445c5aeb8.JPG)

I'm really no expert so I might be doing something wrong.

Let me know if I can help in any way.
