### PR TITLE
added GitHub flavored markdown theme

### DIFF
--- a/predawn-gf-markdown.tmTheme
+++ b/predawn-gf-markdown.tmTheme
@@ -1,0 +1,634 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+
+<plist version="1.0">
+<dict>
+	<key>name</key>
+	<string>Predawn for Markdown</string>
+	<key>settings</key>
+	<array>
+		<dict>
+			<key>settings</key>
+			<dict>
+				<key>background</key>
+				<string>#282828</string>
+
+				<key>caret</key>
+				<string>#F18260</string>
+
+				<key>foreground</key>
+				<string>#dddddd</string>
+
+				<key>invisibles</key>
+				<string>#F18260</string>
+
+				<key>lineHighlight</key>
+				<string>#252525</string>
+
+				<key>selection</key>
+				<string>#4C4C4C</string>
+
+				<key>inactiveSelection</key>
+				<string>#3C3C3C</string>
+
+				<key>findHighlight</key>
+				<string>#F18260</string>
+
+				<key>gutterForeground</key>
+				<string>#4C4C4C</string>
+
+				<key>guide</key>
+				<string>#F1826025</string>
+
+				<key>activeGuide</key>
+				<string>#F1826050</string>
+
+				<key>minimapBorder</key>
+				<string>#F1826025</string>
+			</dict>
+		</dict>
+
+
+
+		<!-- BASICS -->
+
+		<dict>
+			<key>name</key>
+			<string>Markdown: Text</string>
+			<key>scope</key>
+			<string>text.html.markdown</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#dddddd</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Heading</string>
+			<key>scope</key>
+			<string>markup.heading, punctuation.definition.heading.markdown</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#F18260</string>
+
+				<key>fontStyle</key>
+				<string>bold</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Bold (Strong)</string>
+			<key>scope</key>
+			<string>markup.bold, markup.bold.markdown</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string>bold</string>
+
+				<key>foreground</key>
+				<string>#f1f1f1</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Italics (Emphasis)</string>
+			<key>scope</key>
+			<string>markup.italic, markup.italic.markdown</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string>italic</string>
+
+				<key>foreground</key>
+				<string>#f1f1f1</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Bold Italics (Strong + Emphasis)</string>
+			<key>scope</key>
+			<string>
+				, markup.italic markup.bold,
+				, markup.bold markup.italic,
+				, markup.italic.markdown markup.bold.markdown,
+				, markup.bold.markdown markup.italic.markdown,
+				, markup.bold.markdown markup.italic,
+				, markup.italic markup.bold.markdown,
+				, markup.bold markup.italic.markdown,
+			</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string>bold italic</string>
+
+				<key>foreground</key>
+				<string>#f1f1f1</string>
+			</dict>
+		</dict>
+
+
+
+		<!-- QUOTES -->
+
+		<dict>
+			<key>name</key>
+			<string>Blockquote Links</string>
+			<key>scope</key>
+			<string>
+				, text.html.markdown markup.quote.markdown entity.name.tag,
+				, text.html.markdown markup.quote.markdown meta.tag,
+				, text.html.markdown markup.quote.markdown meta.tag punctuation.definition.tag,
+				, text.html.markdown markup.quote.markdown meta.tag string.quoted meta.string-contents,
+				, text.html.markdown markup.quote.markdown meta.tag string.quoted punctuation.definition.string,
+				, text.html.markdown markup.quote.markdown meta.tag entity.other.attribute-name,
+				, text.html.markdown markup.quote.markdown markup.kbd.content.markdown,
+				, text.html.markdown markup.quote.markdown meta.link.inline.markdown,
+			</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#4c4c4c</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Blockquote Text</string>
+			<key>scope</key>
+			<string>
+				, markup.quote.markdown,
+				, text.html.markdown markup.quote.markdown markup.bold,
+				, text.html.markdown markup.quote.markdown markup.bold.markdown,
+				, text.html.markdown markup.quote.markdown markup.italic,
+				, text.html.markdown markup.quote.markdown markup.italic.markdown,
+				, text.html.markdown markup.quote.markdown text.html.markdown,
+				, text.html.markdown markup.quote.markdown text.markdown,
+				, text.html.markdown markup.quote.markdown string.other.link.title.markdown,
+			</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#777777</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Blockquote Markings</string>
+			<key>scope</key>
+			<string>punctuation.definition.blockquote.markdown</string>
+			<key>settings</key>
+			<dict>
+				<key>background</key>
+				<string>#4c4c4c</string>
+				<key>foreground</key>
+				<string>#4c4c4c</string>
+			</dict>
+		</dict>
+
+
+
+		<!-- LINKS -->
+
+		<dict>
+			<key>name</key>
+			<string>Image</string>
+			<key>scope</key>
+			<string>meta.link.inline.markdown</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#4c4c4c</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Link Text</string>
+			<key>scope</key>
+			<string>string.other.link.title.markdown</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#bddcdc</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Image</string>
+			<key>scope</key>
+			<string>meta.image.inline.markdown</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#ecec89</string>
+
+				<key>fontStyle</key>
+				<string>bold</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Strings</string>
+			<key>scope</key>
+			<string>constant.character, string, punctuation.definition.string.begin.markdown, punctuation.definition.string.end.markdown,</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#92bfbf</string>
+				<key>fontStyle</key>
+				<string>normal</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markdown Meta</string>
+			<key>scope</key>
+			<string>meta.header.multimarkdown,keyword.other.multimarkdown,string.unquoted.multimarkdown,punctuation.separator.key-value.multimarkdown</string>
+			<key>settings</key>
+			<dict>
+				<key>background</key>
+				<string>#222222</string>
+				<key>foreground</key>
+				<string>#444444</string>
+			</dict>
+		</dict>
+
+		<dict>
+			<key>name</key>
+			<string>Inline code</string>
+			<key>scope</key>
+			<string>
+				, source.smarty.embedded.html,
+				, text.html.markdown meta.disable-markdown entity.name.tag,
+				, text.html.markdown meta.disable-markdown meta.tag,
+				, text.html.markdown meta.disable-markdown meta.tag punctuation.definition.tag,
+				, text.html.markdown meta.disable-markdown meta.tag string.quoted meta.string-contents,
+				, text.html.markdown meta.disable-markdown meta.tag string.quoted punctuation.definition.string,
+				, text.html.markdown meta.disable-markdown meta.tag entity.other.attribute-name,
+				, text.html.markdown meta.paragraph.markdown entity.name.tag,
+				, text.html.markdown meta.paragraph.markdown meta.tag,
+				, text.html.markdown meta.paragraph.markdown meta.tag punctuation.definition.tag,
+				, text.html.markdown meta.paragraph.markdown meta.tag string.quoted meta.string-contents,
+				, text.html.markdown meta.paragraph.markdown meta.tag string.quoted punctuation.definition.string,
+				, text.html.markdown meta.paragraph.markdown meta.tag entity.other.attribute-name,
+				, text.html.markdown markup.list entity.name.tag,
+				, text.html.markdown markup.list meta.tag,
+				, text.html.markdown markup.list meta.tag punctuation.definition.tag,
+				, text.html.markdown markup.list meta.tag string.quoted meta.string-contents,
+				, text.html.markdown markup.list meta.tag string.quoted punctuation.definition.string,
+				, text.html.markdown markup.list meta.tag entity.other.attribute-name,
+				, markup.underline,
+				, markup.underline.link.markdown,
+				, constant.other.reference.link.markdown,
+				, meta.image.reference.markdown,
+			</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#4c4c4c</string>
+			</dict>
+		</dict>
+
+
+
+		<!-- KEYBOARD KEYS -->
+
+		<dict>
+			<key>name</key>
+			<string>Keyboard</string>
+			<key>scope</key>
+			<string>markup.kbd.content.markdown</string>
+			<key>settings</key>
+			<dict>
+				<key>background</key>
+				<string>#999999</string>
+				<key>foreground</key>
+				<string>#151515</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markdown: Punctuation</string>
+			<key>scope</key>
+			<string>punctuation.definition.metadata.markdown,punctuation.definition.string.begin.markdown, punctuation.definition.string.end.markdown, punctuation.definition.constant.markdown, punctuation.separator.key-value.markdown, punctuation.definition.constant.begin.markdown, punctuation.definition.constant.end.markdown,punctuation.definition.bold.markdown, punctuation.definition.italic.markdown, punctuation.definition.strikethrough.markdown, </string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#4c4c4c</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>HTML: Tags</string>
+			<key>scope</key>
+			<string>
+				,constant,
+			</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#4c4c4c</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Markdown: Punctuation</string>
+			<key>scope</key>
+			<string>
+			</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#f49d62</string>
+			</dict>
+		</dict>
+
+
+		<!-- CODE BLOCKS -->
+
+		<dict>
+			<key>name</key>
+			<string>Block code</string>
+			<key>scope</key>
+			<string>markup.raw.block.markdown</string>
+			<key>settings</key>
+			<dict>
+				<!-- <key>background</key>
+				<string>#303030</string> -->
+				<key>foreground</key>
+				<string>#999999</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Inline code</string>
+			<key>scope</key>
+			<string>markup.raw.inline.markdown</string>
+			<key>settings</key>
+			<dict>
+				<!-- <key>background</key>
+				<string>#303030</string> -->
+				<key>foreground</key>
+				<string>#999999</string>
+			</dict>
+		</dict>
+
+
+
+		<!-- CODE HIGHLIGHTING -->
+
+		<dict>
+			<key>name</key>
+			<string>Operators</string>
+			<key>scope</key>
+			<string>keyword.operator</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string></string>
+				<key>foreground</key>
+				<string>#f49d62</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Keywords</string>
+			<key>scope</key>
+			<string>keyword, storage</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string></string>
+				<key>foreground</key>
+				<string>#f49d62</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Types</string>
+			<key>scope</key>
+			<string>storage.type, support.type</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#ecec89</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Functions</string>
+			<key>scope</key>
+			<string>entity.name.function, support.function</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#92bfbf</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Classes</string>
+			<key>scope</key>
+			<string>entity.name.type, entity.other.inherited-class, support.class</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string></string>
+				<key>foreground</key>
+				<string>#ecec89</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Exceptions</string>
+			<key>scope</key>
+			<string>entity.name.exception</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#cf5340</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Numbers</string>
+			<key>scope</key>
+			<string>constant.numeric, markup.raw.block.markdown constant</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#ecec89</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>Punctuation</string>
+			<key>scope</key>
+			<string>punctuation</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string></string>
+				<key>foreground</key>
+				<string>#f1f1f1</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>HTML: Tag Name</string>
+			<key>scope</key>
+			<string>markup.raw.block.markdown entity</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#b4d388</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>HTML: Tag Punctuation</string>
+			<key>scope</key>
+			<string>punctuation.definition.tag</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#92bfbf</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>HTML: Entities</string>
+			<key>scope</key>
+			<string>constant.character.entity</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#f49d62</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>HTML: Attribute Names</string>
+			<key>scope</key>
+			<string>entity.other.attribute-name, text.html.markdown meta.disable-markdown meta.tag.block.any.html string.quoted.double.html, text.html.markdown meta.disable-markdown meta.tag.block.any.html string.quoted.double.html punctuation.definition</string>
+			<key>settings</key>
+			<dict>
+				<key>fontStyle</key>
+				<string></string>
+				<key>foreground</key>
+				<string>#ecec89</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>HTML: Attribute Values</string>
+			<key>scope</key>
+			<string>meta.tag string.quoted, meta.tag string.quoted constant.character.entity</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#bddcdc</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>HTML: Attribute Punctuation</string>
+			<key>scope</key>
+			<string>meta.tag string punctuation,punctuation.definition.entity.html</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#bddcdc</string>
+			</dict>
+		</dict>
+
+		<!-- GIT GUTTER -->
+		<dict>
+			<key>name</key>
+			<string>GitGutter deleted</string>
+			<key>scope</key>
+			<string>markup.deleted.git_gutter</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#CF5340</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>GitGutter changed</string>
+			<key>scope</key>
+			<string>markup.changed.git_gutter</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#92BFBF</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>GitGutter inserted</string>
+			<key>scope</key>
+			<string>markup.inserted.git_gutter</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#B4D388</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>GitGutter ignored</string>
+			<key>scope</key>
+			<string>markup.ignored.git_gutter</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#777777</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>name</key>
+			<string>GitGutter untracked</string>
+			<key>scope</key>
+			<string>markup.untracked.git_gutter</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#777777</string>
+			</dict>
+		</dict>
+
+
+		<!-- WORD & BRACKET HIGHLIGHT -->
+		<dict>
+            <key>name</key>
+            <string>WordHighlight</string>
+            <key>scope</key>
+            <string>wordhighlight</string>
+            <key>settings</key>
+            <dict>
+                <key>foreground</key>
+                <string>#f49d62</string>
+                <key>background</key>
+                <string>#f49d62</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>name</key>
+            <string>BracketHighlighter</string>
+            <key>scope</key>
+            <string>brackethighlighter.default</string>
+            <key>settings</key>
+            <dict>
+                <key>foreground</key>
+                <string>#f49d62</string>
+                <key>background</key>
+                <string>#f49d62</string>
+            </dict>
+        </dict>
+
+
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
Added a GitHub Flavored Markdown Theme inspired by Sublime [MarkdownEditing](https://github.com/SublimeText-Markdown/MarkdownEditing) Theme. See [this Tweet](https://twitter.com/MrLoh/status/522874517975465984) for a screenshot. 