### PR TITLE
Enhanced visibility for minimap selection

### DIFF
--- a/predawn-DEV.sublime-theme
+++ b/predawn-DEV.sublime-theme
@@ -347,7 +347,7 @@
 
     {
         "class": "minimap_control",
-        "viewport_color": [241, 130, 96, 10]
+        "viewport_color": [241, 130, 96, 30]
     },
 
         //

--- a/predawn.sublime-theme
+++ b/predawn.sublime-theme
@@ -347,7 +347,7 @@
 
     {
         "class": "minimap_control",
-        "viewport_color": [241, 130, 96, 10]
+        "viewport_color": [241, 130, 96, 30]
     },
 
         //


### PR DESCRIPTION
I am using Tomorrow Night - Bright color scheme and the default 10% opacity value just wasn't visible at all which section of the minimap was being viewed, so decided to pull up the value a bit. 