### PR TITLE
Fix 'Use Gitignore' has no style. Fixes #168

### DIFF
--- a/predawn-DEV.sublime-theme
+++ b/predawn-DEV.sublime-theme
@@ -667,6 +667,23 @@
     "layer0.texture": "Predawn/assets/icon-context-on.png"
   },
   {
+    // Use gitignore button
+    "class": "icon_use_gitignore",
+    "layer0.opacity": 1.0,
+    "content_margin": [12, 12],
+    "layer0.tint": "#555555"
+  },
+  {
+    "class": "icon_use_gitignore",
+    "parents": [{"class": "icon_button_control", "attributes": ["hover"]}],
+    "layer0.tint": "#ffffff"
+  },
+  {
+    "class": "icon_use_gitignore",
+    "parents": [{"class": "icon_button_control", "attributes": ["selected"]}],
+    "layer0.tint": "#f18260"
+  },
+  {
     // Use search buffer
     "class": "icon_use_buffer",
     "layer0.texture": "Predawn/assets/icon-buffer-off.png",

--- a/predawn.sublime-theme
+++ b/predawn.sublime-theme
@@ -703,6 +703,23 @@
     "layer0.texture": "Predawn/assets/icon-context-on.png"
   },
   {
+    // Use gitignore button
+    "class": "icon_use_gitignore",
+    "layer0.opacity": 1.0,
+    "content_margin": [12, 12],
+    "layer0.tint": "#555555"
+  },
+  {
+    "class": "icon_use_gitignore",
+    "parents": [{"class": "icon_button_control", "attributes": ["hover"]}],
+    "layer0.tint": "#ffffff"
+  },
+  {
+    "class": "icon_use_gitignore",
+    "parents": [{"class": "icon_button_control", "attributes": ["selected"]}],
+    "layer0.tint": "#f18260"
+  },
+  {
     // Use search buffer
     "class": "icon_use_buffer",
     "layer0.texture": "Predawn/assets/icon-buffer-off.png",


### PR DESCRIPTION
Note: there are no Predawn icons for that feature, so by not linking to any png resource + using `tint`, the native ST4 icon for that feature will be used, while keeping the colors / feel of Predawn.